### PR TITLE
New scenario: kubectl debug

### DIFF
--- a/kubectl-debug/background.sh
+++ b/kubectl-debug/background.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x # output in /var/log/killercoda
+
+touch /tmp/finished

--- a/kubectl-debug/finish.md
+++ b/kubectl-debug/finish.md
@@ -1,0 +1,5 @@
+<br>
+
+### WELL DONE !
+
+You solved this challenge!

--- a/kubectl-debug/index.json
+++ b/kubectl-debug/index.json
@@ -1,0 +1,23 @@
+{
+  "title": "kubectl debug node",
+  "description": "How to use Inspektor Gadget with kubectl debug node",
+  "details": {
+    "intro": {
+      "text": "intro.md",
+      "background": "background.sh",
+      "foreground": "foreground.sh"
+    },
+    "steps": [
+      {
+        "title": "Running kubectl debug node",
+        "text": "step1.md"
+      }
+    ],
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "imageid": "kubernetes-kubeadm-1node"
+  }
+}

--- a/kubectl-debug/intro.md
+++ b/kubectl-debug/intro.md
@@ -1,0 +1,8 @@
+
+<br>
+
+### Welcome !
+
+In this scenario we'll learn how to use Inspektor Gadget with kubectl debug node without installation.
+
+**HAVE FUN**

--- a/kubectl-debug/step1.md
+++ b/kubectl-debug/step1.md
@@ -1,0 +1,19 @@
+Learn about the kubectl debug node command:
+
+`kubectl debug --help`{{exec}}
+
+Find out the name of the worker nodes:
+
+`kubectl get node`{{exec}}
+
+List the gadgets:
+
+`kubectl debug node/controlplane -ti --image=ghcr.io/inspektor-gadget/ig -- ig help`{{exec}}
+
+Run some commands:
+
+`kubectl debug node/controlplane -ti --image=ghcr.io/inspektor-gadget/ig -- ig --auto-sd-unit-restart list-containers`{{exec}}
+
+`kubectl debug node/controlplane -ti --image=ghcr.io/inspektor-gadget/ig -- ig --auto-sd-unit-restart trace exec`{{exec}}
+
+`kubectl debug node/controlplane -ti --image=ghcr.io/inspektor-gadget/ig -- ig --auto-sd-unit-restart top ebpf`{{exec}}

--- a/structure.json
+++ b/structure.json
@@ -1,5 +1,6 @@
 {
   "items": [
+    { "path": "kubectl-debug" },
     { "path": "install" },
     { "path": "snapshot-process" }
   ]


### PR DESCRIPTION
# New scenario: kubectl debug

This new scenario uses the ig container image on Kubernetes with the command "kubectl debug node" as explained on:

https://github.com/inspektor-gadget/inspektor-gadget/blob/main/docs/ig.md#using-ig-with-kubectl-debug-node

## How to use

This PR could be validated on https://killercoda.com/albantest

## Testing done

Tested with the link above.